### PR TITLE
Upgrade fast-xml-parser to 4.5.4 and fix PDF viewer static resource import

### DIFF
--- a/force-app/main/default/lwc/pdfViewer/pdfViewer.js
+++ b/force-app/main/default/lwc/pdfViewer/pdfViewer.js
@@ -1,49 +1,50 @@
-import { LightningElement, api } from 'lwc';
-import { loadStyle, loadScript } from 'lightning/platformResourceLoader';
-import PDFJS from '@salesforce/resourceUrl/pdfobj'; // Reference the Static Resource 'pdfjs5p'
+import { LightningElement, api } from "lwc";
+import { loadScript } from "lightning/platformResourceLoader";
+import PDFJS from "@salesforce/resourceUrl/pdfjs5p"; // Use the pdf.js library
 
 export default class PdfViewer extends LightningElement {
-    @api recordId;
-    isModalOpen = false; // Track if modal is open
-    pdfUrl = 'https://uwaterloo.ca/onbase/sites/default/files/uploads/documents/sampleunsecuredpdf.pdf'; // Your PDF URL
+  @api recordId;
+  isModalOpen = false; // Track if modal is open
+  pdfUrl =
+    "https://uwaterloo.ca/onbase/sites/default/files/uploads/documents/sampleunsecuredpdf.pdf"; // Your PDF URL
 
-    // Variables to store PDF.js components
-    pdfLib;
-    pdfDoc;
-    pageNum = 1;
-    canvas;
+  // Variables to store PDF.js components
+  pdfLib;
+  pdfDoc;
+  pageNum = 1;
+  canvas;
 
-    async connectedCallback() {
-        const pdfjsUrl = PDFJS + '/pdfobject.js'; // PDF.js main library URL
-        console.log('pdfjsUrl:', pdfjsUrl);
-        console.log('connectedCallback is called');
-        try {
-            // Load PDF.js from the Static Resource
-            await loadScript(this, pdfjsUrl); // Load the main PDF.js script
-            console.log('PDF.js loaded from Static Resource');
+  async connectedCallback() {
+    const pdfjsUrl = PDFJS; // pdf.js library URL
+    console.log("pdfjsUrl:", pdfjsUrl);
+    console.log("connectedCallback is called");
+    try {
+      // Load PDF.js from the Static Resource
+      await loadScript(this, pdfjsUrl); // Load the main PDF.js script
+      console.log("PDF.js loaded from Static Resource");
 
-            // Access the PDF.js global object
-            if (window['pdfjsLib']) {
-                this.pdfLib = window['pdfjsLib']; // Access the PDF.js global object
-                this.pdfLib.GlobalWorkerOptions.workerSrc = null; // Disable worker script
-                console.log('PDF.js is available:', this.pdfLib);
-            } else {
-                console.error('PDF.js is not available in window object!');
-            }
-        } catch (error) {
-            console.error('Error loading PDF.js from Static Resource:', error);
-        }
+      // Access the PDF.js global object
+      if (window.pdfjsLib) {
+        this.pdfLib = window.pdfjsLib; // Access the PDF.js global object
+        this.pdfLib.GlobalWorkerOptions.workerSrc = null; // Disable worker script
+        console.log("PDF.js is available:", this.pdfLib);
+      } else {
+        console.error("PDF.js is not available in window object!");
+      }
+    } catch (error) {
+      console.error("Error loading PDF.js from Static Resource:", error);
     }
+  }
 
-    openModal() {
-        this.isModalOpen = true;
-    }
+  openModal() {
+    this.isModalOpen = true;
+  }
 
-    closeModal() {
-        this.isModalOpen = false;
-        const closeEvent = new CustomEvent('close');
-        this.dispatchEvent(closeEvent);
-    }
+  closeModal() {
+    this.isModalOpen = false;
+    const closeEvent = new CustomEvent("close");
+    this.dispatchEvent(closeEvent);
+  }
 
-    // Additional methods to handle PDF rendering can be added here
+  // Additional methods to handle PDF rendering can be added here
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4843,9 +4843,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
-      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.4.tgz",
+      "integrity": "sha512-jE8ugADnYOBsu1uaoayVl1tVKAMNOXyjwvv2U6udEA2ORBhDooJDWoGxTkhd4Qn4yh59JVVt/pKXtjPwx9OguQ==",
       "dev": true,
       "funding": [
         {
@@ -4855,7 +4855,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^1.1.1"
+        "strnum": "^1.0.5"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"

--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
     "**/{aura,lwc}/**/*.js": [
       "eslint"
     ]
+  },
+  "overrides": {
+    "fast-xml-parser": "4.5.4"
   }
 }


### PR DESCRIPTION
### Motivation
- Ensure a transitive dependency `fast-xml-parser` is pinned to a non-vulnerable/minor upgraded release so downstream tooling that depends on it (via `@lwc/eslint-plugin-lwc`) uses the intended version. 
- Fix the PDF viewer component to load the correct static resource for PDF.js so the component can access the expected `pdfjsLib` global.

### Description
- Add an `overrides` entry in `package.json` to pin `fast-xml-parser` to `4.5.4` so transitive resolution is controlled (`"overrides": { "fast-xml-parser": "4.5.4" }`).
- Refresh the lockfile (`package-lock.json`) so the resolved `fast-xml-parser` version, tarball URL and integrity are updated from `4.5.3` to `4.5.4`.
- Update `force-app/main/default/lwc/pdfViewer/pdfViewer.js` to import the correct static resource `@salesforce/resourceUrl/pdfjs5p`, remove the unused `loadStyle` import, simplify script URL usage, and access `window.pdfjsLib` via dot notation.

### Testing
- Ran `npm install` to refresh dependencies and update the lockfile; install completed successfully.
- Ran the test suite with `npm test` (which invokes `sfdx-lwc-jest`) and the unit tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6840497f5e20833392ccb3a09cc8d77b)